### PR TITLE
Integrate Dialyzer

### DIFF
--- a/lib/job_bot/accounts/guardian.ex
+++ b/lib/job_bot/accounts/guardian.ex
@@ -4,6 +4,8 @@ defmodule JobBot.Accounts.Guardian do
   alias JobBot.Accounts
   alias JobBot.Accounts.User
 
+  @dialyzer {:nowarn_function, resource_from_claims: 1}
+
   def subject_for_token(%User{} = user, _claims) do
     {:ok, to_string(user.id)}
   end
@@ -17,7 +19,7 @@ defmodule JobBot.Accounts.Guardian do
     {:ok, user}
   end
 
-  def resource_from_claims(_claims), do: {:error, :reason_for_error}
+  def resource_from_claims(_), do: {:error, :reason_for_error}
 
   def signed_token(user) do
     Phoenix.Token.sign(JobBotWeb.Endpoint, token_salt(), user.id)

--- a/lib/job_bot/crawler_supervisor.ex
+++ b/lib/job_bot/crawler_supervisor.ex
@@ -14,7 +14,13 @@ defmodule JobBot.CrawlerSupervisor do
   def start_child(module, job_search) do
     job_search_id = Map.get(job_search, :id)
     ref = JobBot.Crawler.ref(job_search_id, module)
-    spec = Supervisor.Spec.worker(module, [job_search], restart: :temporary, id: ref)
+    spec = %{
+      id: ref,
+      start: {module, :start_link, [job_search]},
+      restart: :temporary,
+      type: :worker
+    }
+
     DynamicSupervisor.start_child(__MODULE__, spec)
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,8 @@ defmodule JobBot.Mixfile do
       compilers: [:phoenix, :gettext] ++ Mix.compilers,
       start_permanent: Mix.env == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      dialyzer: [plt_add_deps: :transitive]
     ]
   end
 
@@ -51,6 +52,7 @@ defmodule JobBot.Mixfile do
       {:jason, "~> 1.0"},
       {:distillery, "~> 2.0", runtime: false},
       {:scrivener_ecto, "~> 2.0"},
+      {:dialyxir, "~> 0.5.0", only: [:dev], runtime: false},
       {:mock, "~> 0.3.2", only: :test},
       {:ex_machina, "~> 2.2", only: :test},
       {:phoenix_live_view, github: "phoenixframework/phoenix_live_view"},

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,7 @@
   "cowlib": {:hex, :cowlib, "2.7.3", "a7ffcd0917e6d50b4d5fb28e9e2085a0ceb3c97dea310505f7460ff5ed764ce9", [:rebar3], [], "hexpm"},
   "db_connection": {:hex, :db_connection, "2.1.1", "a51e8a2ee54ef2ae6ec41a668c85787ed40cb8944928c191280fe34c15b76ae5", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm"},
   "decimal": {:hex, :decimal, "1.8.0", "ca462e0d885f09a1c5a342dbd7c1dcf27ea63548c65a65e67334f4b61803822e", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "distillery": {:hex, :distillery, "2.0.12", "6e78fe042df82610ac3fa50bd7d2d8190ad287d120d3cd1682d83a44e8b34dfb", [:mix], [{:artificery, "~> 0.2", [hex: :artificery, repo: "hexpm", optional: false]}], "hexpm"},
   "ecto": {:hex, :ecto, "3.2.3", "51274df79862845b388733fddcf6f107d0c8c86e27abe7131fa98f8d30761bda", [:mix], [{:decimal, "~> 1.6", [hex: :decimal, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
   "ecto_sql": {:hex, :ecto_sql, "3.2.0", "751cea597e8deb616084894dd75cbabfdbe7255ff01e8c058ca13f0353a3921b", [:mix], [{:db_connection, "~> 2.1", [hex: :db_connection, repo: "hexpm", optional: false]}, {:ecto, "~> 3.2.0", [hex: :ecto, repo: "hexpm", optional: false]}, {:myxql, "~> 0.2.0", [hex: :myxql, repo: "hexpm", optional: true]}, {:postgrex, "~> 0.15.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:telemetry, "~> 0.4.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This PR integrates the Dialyzer for static analysis.  This should help improve the quality of the codebase, making it more consistent, making it easier to comply with third-party integrations, and making it less prone to errors and discrepancies.

As an example, this PR also fixes a discrepancy Dialyzer found with the call to `DynamicSupervisor.start_child/2` in `JobBot.CrawlerSupervisor`